### PR TITLE
Shadow Boost

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -51,6 +51,10 @@ struct TrainerMonCustomized
     bool8 gender : 2;
     bool8 isShiny : 1;
     bool8 isShadow:1;
+    bool8 isXD;
+    u8 boostLevel;
+    u8 shadowAggro;
+    u8 shadowID;
     u16 heartGauge;
 };
 

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -330,14 +330,14 @@ struct BattlePokemon
     /*0x51*/ u32 status2;
     /*0x55*/ u32 otId;
     /*0x59*/ u8 metLevel;
-    /*0x5A*/ u8 isShadow;       //Only needs 1 bit; potentially look into what needs to be changed to use these as a bitfield
-    /*0x5B*/ u8 boostLevel;     //Only needs 2 bits
-    /*0x5C*/ u8 shadowAggro;    //Only needs 3 bits
-    /*0x5D*/ u8 isReverse;      //Only needs 1 bit
-    /*0x5E*/ u8 isXD;           //Only needs 1 bit
-    /*0x5F*/ u8 shadowID;
-    /*0x60*/ u16 heartVal;
-    /*0x62*/ u16 heartMax;
+    /*0x5A*/ u8 isShadow:1;
+    /*0x5A*/ u8 boostLevel:2;
+    /*0x5A*/ u8 shadowAggro:3;
+    /*0x5A*/ u8 isReverse:1;
+    /*0x5A*/ u8 isXD:1;
+    /*0x5B*/ u8 shadowID;
+    /*0x5C*/ u16 heartVal;
+    /*0x5E*/ u16 heartMax;
 };
 
 struct SpeciesInfo /*0x24*/

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -92,6 +92,9 @@ enum {
     MON_DATA_WORLD_RIBBON,
     MON_DATA_UNUSED_RIBBONS,
     MON_DATA_IS_SHADOW,
+    MON_DATA_SHADOW_ID,
+    MON_DATA_IS_XD,
+    MON_DATA_BOOST_LEVEL,
     MON_DATA_REVERSE_MODE,
     MON_DATA_HEART_VALUE,
     MON_DATA_HEART_MAX,
@@ -210,9 +213,20 @@ union __attribute__((packed, aligned(2))) NicknameShadowdata
     u8 nickname[POKEMON_NAME_LENGTH];
     struct Shadowdata
     {
-        u8 isReverse;
-        u16 heartValue;
-        u16 heartMax;
+    /* 0x00 */ u16 heartValue;
+    /* 0x02 */ u16 heartMax;
+    /* 0x04 */ u8 shadowID;
+    /* 0x05 */ u8 shadowAggro:3; //Determines chance to enter Reverse Mode
+    /* 0x05 */ u8 boostLevel:2; //Determines how much the Pokemon's stats are boosted before you can catch them
+    /* 0x05 */ u8 isXD:1; //for Shadow Lugia's special case
+    /* 0x05 */ u8 isReverse:1;
+    /* 0x05 */ u8 filler:1;
+    /* 0x06 */ 
+    /* 0x07 */ 
+    /* 0x08 */ 
+    /* 0x09 */ 
+    /* size = 10 */
+        
     } shadowData;
 };
 
@@ -315,8 +329,12 @@ struct BattlePokemon
     /*0x51*/ u32 status2;
     /*0x55*/ u32 otId;
     /*0x59*/ u8 metLevel;
-    /*0x5A*/ u8 isShadow;
-    /*0x5B*/ u8 isReverse;
+    /*0x5A*/ u8 isShadow:1;
+    /*0x5A*/ u8 boostLevel:2;
+    /*0x5A*/ u8 shadowAggro:3;
+    /*0x5A*/ u8 isReverse:1;
+    /*0x5A*/ u8 isXD:1;
+    /*0x5B*/ u8 shadowID;
     /*0x5C*/ u16 heartVal;
     /*0x5E*/ u16 heartMax;
 };

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -512,7 +512,7 @@ bool8 ShouldIgnoreDeoxysForm(u8 caseId, u8 battlerId);
 u16 GetUnionRoomTrainerPic(void);
 u16 GetUnionRoomTrainerClass(void);
 void CreateEnemyEventMon(void);
-void CalculateMonStats(struct Pokemon *mon, bool8 isBoosted);
+void CalculateMonStats(struct Pokemon *mon, bool8 canBeBoosted);
 void BoxMonToMon(const struct BoxPokemon *src, struct Pokemon *dest);
 u8 GetLevelFromMonExp(struct Pokemon *mon);
 u8 GetLevelFromBoxMonExp(struct BoxPokemon *boxMon);

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -94,6 +94,7 @@ enum {
     MON_DATA_IS_SHADOW,
     MON_DATA_SHADOW_ID,
     MON_DATA_IS_XD,
+    MON_DATA_SHADOW_AGGRO,
     MON_DATA_BOOST_LEVEL,
     MON_DATA_REVERSE_MODE,
     MON_DATA_HEART_VALUE,
@@ -511,7 +512,7 @@ bool8 ShouldIgnoreDeoxysForm(u8 caseId, u8 battlerId);
 u16 GetUnionRoomTrainerPic(void);
 u16 GetUnionRoomTrainerClass(void);
 void CreateEnemyEventMon(void);
-void CalculateMonStats(struct Pokemon *mon);
+void CalculateMonStats(struct Pokemon *mon, bool8 isBoosted);
 void BoxMonToMon(const struct BoxPokemon *src, struct Pokemon *dest);
 u8 GetLevelFromMonExp(struct Pokemon *mon);
 u8 GetLevelFromBoxMonExp(struct BoxPokemon *boxMon);

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -330,14 +330,14 @@ struct BattlePokemon
     /*0x51*/ u32 status2;
     /*0x55*/ u32 otId;
     /*0x59*/ u8 metLevel;
-    /*0x5A*/ u8 isShadow:1;
-    /*0x5A*/ u8 boostLevel:2;
-    /*0x5A*/ u8 shadowAggro:3;
-    /*0x5A*/ u8 isReverse:1;
-    /*0x5A*/ u8 isXD:1;
-    /*0x5B*/ u8 shadowID;
-    /*0x5C*/ u16 heartVal;
-    /*0x5E*/ u16 heartMax;
+    /*0x5A*/ u8 isShadow;       //Only needs 1 bit; potentially look into what needs to be changed to use these as a bitfield
+    /*0x5B*/ u8 boostLevel;     //Only needs 2 bits
+    /*0x5C*/ u8 shadowAggro;    //Only needs 3 bits
+    /*0x5D*/ u8 isReverse;      //Only needs 1 bit
+    /*0x5E*/ u8 isXD;           //Only needs 1 bit
+    /*0x5F*/ u8 shadowID;
+    /*0x60*/ u16 heartVal;
+    /*0x62*/ u16 heartMax;
 };
 
 struct SpeciesInfo /*0x24*/

--- a/src/battle_controller_link_opponent.c
+++ b/src/battle_controller_link_opponent.c
@@ -919,6 +919,7 @@ static void SetLinkOpponentMonData(u8 monId)
     case REQUEST_ALL_BATTLE:
         {
             u8 iv;
+            u8 isShadow;
 
             SetMonData(&gEnemyParty[monId], MON_DATA_SPECIES, &battlePokemon->species);
             SetMonData(&gEnemyParty[monId], MON_DATA_HELD_ITEM, &battlePokemon->item);
@@ -952,7 +953,8 @@ static void SetLinkOpponentMonData(u8 monId)
             SetMonData(&gEnemyParty[monId], MON_DATA_SPEED, &battlePokemon->speed);
             SetMonData(&gEnemyParty[monId], MON_DATA_SPATK, &battlePokemon->spAttack);
             SetMonData(&gEnemyParty[monId], MON_DATA_SPDEF, &battlePokemon->spDefense);
-            SetMonData(&gEnemyParty[monId], MON_DATA_IS_SHADOW, &battlePokemon->isShadow);
+            isShadow = battlePokemon->isShadow;
+            SetMonData(&gEnemyParty[monId], MON_DATA_IS_SHADOW, &isShadow);
         }
         break;
     case REQUEST_SPECIES_BATTLE:

--- a/src/battle_controller_link_partner.c
+++ b/src/battle_controller_link_partner.c
@@ -813,6 +813,7 @@ static void SetLinkPartnerMonData(u8 monId)
     case REQUEST_ALL_BATTLE:
         {
             u8 iv;
+            u8 isShadow;
 
             SetMonData(&gPlayerParty[monId], MON_DATA_SPECIES, &battlePokemon->species);
             SetMonData(&gPlayerParty[monId], MON_DATA_HELD_ITEM, &battlePokemon->item);
@@ -846,7 +847,8 @@ static void SetLinkPartnerMonData(u8 monId)
             SetMonData(&gPlayerParty[monId], MON_DATA_SPEED, &battlePokemon->speed);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPATK, &battlePokemon->spAttack);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPDEF, &battlePokemon->spDefense);
-            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &battlePokemon->isShadow);
+            isShadow = battlePokemon->isShadow;
+            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &isShadow);
         }
         break;
     case REQUEST_SPECIES_BATTLE:

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -949,6 +949,7 @@ static void SetOpponentMonData(u8 monId)
     case REQUEST_ALL_BATTLE:
         {
             u8 iv;
+            u8 isShadow;
 
             SetMonData(&gEnemyParty[monId], MON_DATA_SPECIES, &battlePokemon->species);
             SetMonData(&gEnemyParty[monId], MON_DATA_HELD_ITEM, &battlePokemon->item);
@@ -982,7 +983,8 @@ static void SetOpponentMonData(u8 monId)
             SetMonData(&gEnemyParty[monId], MON_DATA_SPEED, &battlePokemon->speed);
             SetMonData(&gEnemyParty[monId], MON_DATA_SPATK, &battlePokemon->spAttack);
             SetMonData(&gEnemyParty[monId], MON_DATA_SPDEF, &battlePokemon->spDefense);
-            SetMonData(&gEnemyParty[monId], MON_DATA_IS_SHADOW, &battlePokemon->isShadow);
+            isShadow = battlePokemon->isShadow;
+            SetMonData(&gEnemyParty[monId], MON_DATA_IS_SHADOW, &isShadow);
         }
         break;
     case REQUEST_SPECIES_BATTLE:

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2206,6 +2206,7 @@ static void SetPlayerMonData(u8 monId)
     case REQUEST_ALL_BATTLE:
         {
             u8 iv;
+            u8 isShadow;
 
             SetMonData(&gPlayerParty[monId], MON_DATA_SPECIES, &battlePokemon->species);
             SetMonData(&gPlayerParty[monId], MON_DATA_HELD_ITEM, &battlePokemon->item);
@@ -2239,7 +2240,8 @@ static void SetPlayerMonData(u8 monId)
             SetMonData(&gPlayerParty[monId], MON_DATA_SPEED, &battlePokemon->speed);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPATK, &battlePokemon->spAttack);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPDEF, &battlePokemon->spDefense);
-            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &battlePokemon->isShadow);
+            isShadow = battlePokemon->isShadow;
+            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &isShadow);
         }
         break;
     case REQUEST_SPECIES_BATTLE:

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1400,7 +1400,7 @@ static void Task_GiveExpToMon(u8 taskId)
             u8 savedActiveBattler;
 
             SetMonData(mon, MON_DATA_EXP, &nextLvlExp);
-            CalculateMonStats(mon);
+            CalculateMonStats(mon, FALSE);
             gainedExp -= nextLvlExp - currExp;
             savedActiveBattler = gActiveBattler;
             gActiveBattler = battlerId;
@@ -1479,7 +1479,7 @@ static void Task_GiveExpWithExpBar(u8 taskId)
                 u8 savedActiveBattler;
 
                 SetMonData(&gPlayerParty[monId], MON_DATA_EXP, &expOnNextLvl);
-                CalculateMonStats(&gPlayerParty[monId]);
+                CalculateMonStats(&gPlayerParty[monId], FALSE);
                 gainedExp -= expOnNextLvl - currExp;
                 savedActiveBattler = gActiveBattler;
                 gActiveBattler = battlerId;
@@ -3471,7 +3471,7 @@ static void Task_LowerHeartValue(u8 taskId)
             u8 savedActiveBattler;
 
             //SetMonData(mon, MON_DATA_HEART_VALUE, &newVal);
-            //CalculateMonStats(mon);
+            //CalculateMonStats(mon, FALSE);
             savedActiveBattler = gActiveBattler;
             gActiveBattler = battlerId;
             //TODO BtlController_EmitTwoReturnValues(BUFFER_B, RET_VALUE_LEVELED_UP, amount);
@@ -3548,7 +3548,7 @@ static void Task_LowerHeartValWithBar(u8 taskId)
                 u8 savedActiveBattler;
 
                 SetMonData(&gPlayerParty[monId], MON_DATA_HEART_VALUE, &hVal);
-                // CalculateMonStats(&gPlayerParty[monId]);
+                // CalculateMonStats(&gPlayerParty[monId], FALSE);
                 savedActiveBattler = gActiveBattler;
                 gActiveBattler = battlerId;
                 //TODO BtlController_EmitTwoReturnValues(BUFFER_B, RET_VALUE_LEVELED_UP, amount);

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -1008,6 +1008,7 @@ static void SetPlayerPartnerMonData(u8 monId)
     case REQUEST_ALL_BATTLE:
         {
             u8 iv;
+            u8 isShadow;
 
             SetMonData(&gPlayerParty[monId], MON_DATA_SPECIES, &battlePokemon->species);
             SetMonData(&gPlayerParty[monId], MON_DATA_HELD_ITEM, &battlePokemon->item);
@@ -1041,7 +1042,8 @@ static void SetPlayerPartnerMonData(u8 monId)
             SetMonData(&gPlayerParty[monId], MON_DATA_SPEED, &battlePokemon->speed);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPATK, &battlePokemon->spAttack);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPDEF, &battlePokemon->spDefense);
-            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &battlePokemon->isShadow);
+            isShadow = battlePokemon->isShadow;
+            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &isShadow);
         }
         break;
     case REQUEST_SPECIES_BATTLE:

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -343,7 +343,7 @@ static void Task_GiveExpToMon(u8 taskId)
             u8 savedActiveBank;
 
             SetMonData(mon, MON_DATA_EXP, &nextLvlExp);
-            CalculateMonStats(mon);
+            CalculateMonStats(mon, FALSE);
             gainedExp -= nextLvlExp - currExp;
             savedActiveBank = gActiveBattler;
             gActiveBattler = battlerId;
@@ -422,7 +422,7 @@ static void Task_GiveExpWithExpBar(u8 taskId)
                 u8 savedActiveBank;
 
                 SetMonData(&gPlayerParty[monId], MON_DATA_EXP, &expOnNextLvl);
-                CalculateMonStats(&gPlayerParty[monId]);
+                CalculateMonStats(&gPlayerParty[monId], FALSE);
                 gainedExp -= expOnNextLvl - currExp;
                 savedActiveBank = gActiveBattler;
                 gActiveBattler = battlerId;
@@ -2062,7 +2062,7 @@ static void Task_LowerHeartValue(u8 taskId)
             u8 savedActiveBattler;
 
             SetMonData(mon, MON_DATA_HEART_VALUE, &newVal);
-            //CalculateMonStats(mon);
+            //CalculateMonStats(mon, FALSE);
             savedActiveBattler = gActiveBattler;
             gActiveBattler = battlerId;
             // TODOSHADOW BtlController_EmitTwoReturnValues(BUFFER_B, RET_VALUE_LEVELED_UP, amount);
@@ -2133,7 +2133,7 @@ static void Task_LowerHeartValWithBar(u8 taskId)
 
                 SetMonData(&gPlayerParty[monId], MON_DATA_HEART_VALUE, &newVal);
                 // TODOSHADOW Replace CalculateMonStats with any necessary changes based on section unlocks (new moves, etc)
-                // CalculateMonStats(&gPlayerParty[monId]);
+                // CalculateMonStats(&gPlayerParty[monId], FALSE);
                 savedActiveBattler = gActiveBattler;
                 gActiveBattler = battlerId;
                 BtlController_EmitTwoReturnValues(BUFFER_B, RET_VALUE_LEVELED_UP, amount);

--- a/src/battle_controller_recorded_opponent.c
+++ b/src/battle_controller_recorded_opponent.c
@@ -908,6 +908,7 @@ static void SetRecordedOpponentMonData(u8 monId)
     case REQUEST_ALL_BATTLE:
         {
             u8 iv;
+            u8 isShadow;
 
             SetMonData(&gEnemyParty[monId], MON_DATA_SPECIES, &battlePokemon->species);
             SetMonData(&gEnemyParty[monId], MON_DATA_HELD_ITEM, &battlePokemon->item);
@@ -941,7 +942,8 @@ static void SetRecordedOpponentMonData(u8 monId)
             SetMonData(&gEnemyParty[monId], MON_DATA_SPEED, &battlePokemon->speed);
             SetMonData(&gEnemyParty[monId], MON_DATA_SPATK, &battlePokemon->spAttack);
             SetMonData(&gEnemyParty[monId], MON_DATA_SPDEF, &battlePokemon->spDefense);
-            SetMonData(&gEnemyParty[monId], MON_DATA_IS_SHADOW, &battlePokemon->isShadow);
+            isShadow = battlePokemon->isShadow;
+            SetMonData(&gEnemyParty[monId], MON_DATA_IS_SHADOW, &isShadow);
         }
         break;
     case REQUEST_SPECIES_BATTLE:

--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -887,6 +887,7 @@ static void SetRecordedPlayerMonData(u8 monId)
     case REQUEST_ALL_BATTLE:
         {
             u8 iv;
+            u8 isShadow;
 
             SetMonData(&gPlayerParty[monId], MON_DATA_SPECIES, &battlePokemon->species);
             SetMonData(&gPlayerParty[monId], MON_DATA_HELD_ITEM, &battlePokemon->item);
@@ -920,7 +921,8 @@ static void SetRecordedPlayerMonData(u8 monId)
             SetMonData(&gPlayerParty[monId], MON_DATA_SPEED, &battlePokemon->speed);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPATK, &battlePokemon->spAttack);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPDEF, &battlePokemon->spDefense);
-            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &battlePokemon->isShadow);
+            isShadow = battlePokemon->isShadow;
+            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &isShadow);
         }
         break;
     case REQUEST_SPECIES_BATTLE:

--- a/src/battle_controller_wally.c
+++ b/src/battle_controller_wally.c
@@ -815,6 +815,7 @@ static void SetWallyMonData(u8 monId)
     case REQUEST_ALL_BATTLE:
         {
             u8 iv;
+            u8 isShadow;
 
             SetMonData(&gPlayerParty[monId], MON_DATA_SPECIES, &battlePokemon->species);
             SetMonData(&gPlayerParty[monId], MON_DATA_HELD_ITEM, &battlePokemon->item);
@@ -848,7 +849,8 @@ static void SetWallyMonData(u8 monId)
             SetMonData(&gPlayerParty[monId], MON_DATA_SPEED, &battlePokemon->speed);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPATK, &battlePokemon->spAttack);
             SetMonData(&gPlayerParty[monId], MON_DATA_SPDEF, &battlePokemon->spDefense);
-            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &battlePokemon->isShadow);
+            isShadow = battlePokemon->isShadow;
+            SetMonData(&gPlayerParty[monId], MON_DATA_IS_SHADOW, &isShadow);
         }
         break;
     case REQUEST_SPECIES_BATTLE:

--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -455,7 +455,7 @@ static void SetPlayerAndOpponentParties(void)
                     SetMonData(&gPlayerParty[i], MON_DATA_HP_EV + j, &evs);
             }
 
-            CalculateMonStats(&gPlayerParty[i]);
+            CalculateMonStats(&gPlayerParty[i], FALSE);
             friendship = 0;
             for (k = 0; k < MAX_MON_MOVES; k++)
                 SetMonMoveAvoidReturn(&gPlayerParty[i], gFacilityTrainerMons[monId].moves[k], k);
@@ -496,7 +496,7 @@ static void SetPlayerAndOpponentParties(void)
                     SetMonData(&gEnemyParty[i], MON_DATA_HP_EV + j, &evs);
             }
 
-            CalculateMonStats(&gEnemyParty[i]);
+            CalculateMonStats(&gEnemyParty[i], TRUE);
             for (k = 0; k < MAX_MON_MOVES; k++)
                 SetMonMoveAvoidReturn(&gEnemyParty[i], gFacilityTrainerMons[monId].moves[k], k);
             SetMonData(&gEnemyParty[i], MON_DATA_HELD_ITEM, &gBattleFrontierHeldItems[gFacilityTrainerMons[monId].itemTableId]);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2118,6 +2118,9 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
                 {
                     bool8 shad = TRUE;
                     SetMonData(&party[i], MON_DATA_IS_SHADOW, &shad);
+                    SetMonData(&party[i], MON_DATA_SHADOW_ID, &partyData[i].shadowID);
+                    SetMonData(&party[i], MON_DATA_IS_XD, &partyData[i].isXD);
+                    SetMonData(&party[i], MON_DATA_BOOST_LEVEL, &partyData[i].boostLevel);
                     SetMonData(&party[i], MON_DATA_HEART_VALUE, &partyData[i].heartGauge);
                     SetMonData(&party[i], MON_DATA_HEART_MAX, &partyData[i].heartGauge);
                 }
@@ -2125,7 +2128,10 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
                 {
                     SetMonData(&party[i], MON_DATA_NICKNAME, partyData[i].nickname);
                 }
-                CalculateMonStats(&party[i]);
+                if (partyData[i].isShadow)
+                    CalculateMonStats(&party[i], true);
+                else
+                    CalculateMonStats(&party[i], false);
             }
             }
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2129,9 +2129,9 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
                     SetMonData(&party[i], MON_DATA_NICKNAME, partyData[i].nickname);
                 }
                 if (partyData[i].isShadow)
-                    CalculateMonStats(&party[i], true);
+                    CalculateMonStats(&party[i], TRUE);
                 else
-                    CalculateMonStats(&party[i], false);
+                    CalculateMonStats(&party[i], FALSE);
             }
             }
 
@@ -5483,7 +5483,7 @@ static void HandleEndTurn_FinishBattle(void)
         #if B_RECALCULATE_STATS >= GEN_5
             // Recalculate the stats of every party member before the end
             if (!changedForm)
-                CalculateMonStats(&gPlayerParty[i]);
+                CalculateMonStats(&gPlayerParty[i], FALSE);
         #endif
         }
         // Clear battle mon species to avoid a bug on the next battle that causes

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2119,6 +2119,7 @@ u8 CreateNPCTrainerPartyFromTrainer(struct Pokemon *party, const struct Trainer 
                     bool8 shad = TRUE;
                     SetMonData(&party[i], MON_DATA_IS_SHADOW, &shad);
                     SetMonData(&party[i], MON_DATA_SHADOW_ID, &partyData[i].shadowID);
+                    SetMonData(&party[i], MON_DATA_SHADOW_AGGRO, &partyData[i].shadowAggro);
                     SetMonData(&party[i], MON_DATA_IS_XD, &partyData[i].isXD);
                     SetMonData(&party[i], MON_DATA_BOOST_LEVEL, &partyData[i].boostLevel);
                     SetMonData(&party[i], MON_DATA_HEART_VALUE, &partyData[i].heartGauge);

--- a/src/battle_pike.c
+++ b/src/battle_pike.c
@@ -1162,7 +1162,7 @@ bool32 TryGenerateBattlePikeWildMon(bool8 checkKeenEyeIntimidate)
     for (i = 0; i < MAX_MON_MOVES; i++)
         SetMonMoveSlot(&gEnemyParty[0], wildMons[headerId][pikeMonId].moves[i], i);
 
-    CalculateMonStats(&gEnemyParty[0]);
+    CalculateMonStats(&gEnemyParty[0], TRUE);
     return TRUE;
 }
 

--- a/src/battle_pyramid.c
+++ b/src/battle_pyramid.c
@@ -1408,7 +1408,7 @@ void GenerateBattlePyramidWildMon(void)
         for (i = 0; i < NUM_STATS; i++)
             SetMonData(&gEnemyParty[0], MON_DATA_HP_IV + i, &id);
     }
-    CalculateMonStats(&gEnemyParty[0]);
+    CalculateMonStats(&gEnemyParty[0], TRUE);
 }
 
 u8 GetPyramidRunMultiplier(void)

--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -3037,7 +3037,7 @@ static void FillPartnerParty(u16 trainerId)
             SetMonData(&gPlayerParty[MULTI_PARTY_SIZE + i], MON_DATA_OT_NAME, gTrainers[TRAINER_STEVEN].trainerName);
             j = MALE;
             SetMonData(&gPlayerParty[MULTI_PARTY_SIZE + i], MON_DATA_OT_GENDER, &j);
-            CalculateMonStats(&gPlayerParty[MULTI_PARTY_SIZE + i]);
+            CalculateMonStats(&gPlayerParty[MULTI_PARTY_SIZE + i], FALSE);
         }
     }
     else if (trainerId >= TRAINER_CUSTOM_PARTNER)
@@ -3158,7 +3158,7 @@ static void FillPartnerParty(u16 trainerId)
                 {
                     SetMonData(&gPlayerParty[i+3], MON_DATA_NICKNAME, partyData[i].nickname);
                 }
-                CalculateMonStats(&gPlayerParty[i+3]);
+                CalculateMonStats(&gPlayerParty[i+3], FALSE);
             }
             }
 
@@ -3712,7 +3712,7 @@ void TrySetLinkBattleTowerEnemyPartyLevel(void)
             if (species)
             {
                 SetMonData(&gEnemyParty[i], MON_DATA_EXP, &gExperienceTables[gSpeciesInfo[species].growthRate][enemyLevel]);
-                CalculateMonStats(&gEnemyParty[i]);
+                CalculateMonStats(&gEnemyParty[i], TRUE);
             }
         }
     }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -10889,7 +10889,7 @@ void CopyMonAbilityAndTypesToBattleMon(u32 battler, struct Pokemon *mon)
 
 void RecalcBattlerStats(u32 battler, struct Pokemon *mon)
 {
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, FALSE);
     CopyMonLevelAndBaseStatsToBattleMon(battler, mon);
     CopyMonAbilityAndTypesToBattleMon(battler, mon);
 }

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -301,7 +301,7 @@ static void ApplyDaycareExperience(struct Pokemon *mon)
     }
 
     // Re-calculate the mons stats at its new level.
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, FALSE);
 }
 
 static u16 TakeSelectedPokemonFromDaycare(struct DaycareMon *daycareMon)
@@ -319,7 +319,7 @@ static u16 TakeSelectedPokemonFromDaycare(struct DaycareMon *daycareMon)
     if (newSpecies != SPECIES_NONE)
     {
         SetMonData(&pokemon, MON_DATA_SPECIES, &newSpecies);
-        CalculateMonStats(&pokemon);
+        CalculateMonStats(&pokemon, FALSE);
         species = newSpecies;
     }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -3381,7 +3381,7 @@ static void DebugAction_Give_Pokemon_ComplexCreateMon(u8 taskId) //https://githu
         if (iv_val != 32 && iv_val != 0xFF)
             SetMonData(&mon, MON_DATA_HP_IV + i, &iv_val);
     }
-    CalculateMonStats(&mon);
+    CalculateMonStats(&mon, FALSE);
 
     //Moves
     for (i = 0; i < MAX_MON_MOVES; i++)

--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -384,7 +384,7 @@ static void AddHatchedMonToParty(u8 id)
     SetMonData(mon, MON_DATA_MET_LOCATION, &metLocation);
 
     MonRestorePP(mon);
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, FALSE);
 }
 
 void ScriptHatchMon(void)

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -580,7 +580,7 @@ static void CreateShedinja(u16 preEvoSpecies, struct Pokemon *mon)
         data = MAIL_NONE;
         SetMonData(&gPlayerParty[gPlayerPartyCount], MON_DATA_MAIL, &data);
 
-        CalculateMonStats(&gPlayerParty[gPlayerPartyCount]);
+        CalculateMonStats(&gPlayerParty[gPlayerPartyCount], FALSE);
         CalculatePlayerPartyCount();
 
         GetSetPokedexFlag(SpeciesToNationalPokedexNum(gEvolutionTable[preEvoSpecies][1].targetSpecies), FLAG_SET_SEEN);
@@ -773,7 +773,7 @@ static void Task_EvolutionScene(u8 taskId)
             PlayBGM(MUS_EVOLVED);
             gTasks[taskId].tState++;
             SetMonData(mon, MON_DATA_SPECIES, (void *)(&gTasks[taskId].tPostEvoSpecies));
-            CalculateMonStats(mon);
+            CalculateMonStats(mon, FALSE);
             EvolutionRenameMon(mon, gTasks[taskId].tPreEvoSpecies, gTasks[taskId].tPostEvoSpecies);
             GetSetPokedexFlag(SpeciesToNationalPokedexNum(gTasks[taskId].tPostEvoSpecies), FLAG_SET_SEEN);
             GetSetPokedexFlag(SpeciesToNationalPokedexNum(gTasks[taskId].tPostEvoSpecies), FLAG_SET_CAUGHT);
@@ -1193,7 +1193,7 @@ static void Task_TradeEvolutionScene(u8 taskId)
             PlayFanfare(MUS_EVOLVED);
             gTasks[taskId].tState++;
             SetMonData(mon, MON_DATA_SPECIES, (&gTasks[taskId].tPostEvoSpecies));
-            CalculateMonStats(mon);
+            CalculateMonStats(mon, FALSE);
             EvolutionRenameMon(mon, gTasks[taskId].tPreEvoSpecies, gTasks[taskId].tPostEvoSpecies);
             GetSetPokedexFlag(SpeciesToNationalPokedexNum(gTasks[taskId].tPostEvoSpecies), FLAG_SET_SEEN);
             GetSetPokedexFlag(SpeciesToNationalPokedexNum(gTasks[taskId].tPostEvoSpecies), FLAG_SET_CAUGHT);

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -2487,7 +2487,7 @@ void CreateFrontierBrainPokemon(void)
                 friendship = 0;
         }
         SetMonData(&gEnemyParty[monPartyId], MON_DATA_FRIENDSHIP, &friendship);
-        CalculateMonStats(&gEnemyParty[monPartyId]);
+        CalculateMonStats(&gEnemyParty[monPartyId], TRUE);
         monPartyId++;
     }
 }

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -5699,7 +5699,7 @@ static void Task_TryItemUseFormChange(u8 taskId)
     case 0:
         targetSpecies = gTasks[taskId].tTargetSpecies;
         SetMonData(mon, MON_DATA_SPECIES, &targetSpecies);
-        CalculateMonStats(mon);
+        CalculateMonStats(mon, FALSE);
         gTasks[taskId].tState++;
         break;
     case 1:
@@ -5800,7 +5800,7 @@ void TryItemHoldFormChange(struct Pokemon *mon)
         SetMonData(mon, MON_DATA_SPECIES, &targetSpecies);
         FreeAndDestroyMonIconSprite(&gSprites[sPartyMenuBoxes[gPartyMenu.slotId].monSpriteId]);
         CreatePartyMonIconSpriteParameterized(targetSpecies, GetMonData(mon, MON_DATA_PERSONALITY, NULL), &sPartyMenuBoxes[gPartyMenu.slotId], 1);
-        CalculateMonStats(mon);
+        CalculateMonStats(mon, FALSE);
         UpdatePartyMonHeldItemSprite(mon, &sPartyMenuBoxes[gPartyMenu.slotId]);
     }
 }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -4124,7 +4124,7 @@ void CalculateMonStats(struct Pokemon *mon, bool8 canBeBoosted)
     {
         newMaxHP = 1;
     }
-    else if (isBoosted == TRUE)
+    else if (canBeBoosted == TRUE)
     {
         s32 n = 2 * gSpeciesInfo[species].baseHP + hpIV;
         newMaxHP = (((n + hpEV / 4) * boostedLevel) / 100) + boostedLevel + 10;
@@ -4141,7 +4141,7 @@ void CalculateMonStats(struct Pokemon *mon, bool8 canBeBoosted)
 
     SetMonData(mon, MON_DATA_MAX_HP, &newMaxHP);
 
-    if (isBoosted == TRUE)
+    if (canBeBoosted == TRUE)
     {
         CALC_BOOSTED_STAT(baseAttack, attackIV, attackEV, STAT_ATK, MON_DATA_ATK)
         CALC_BOOSTED_STAT(baseDefense, defenseIV, defenseEV, STAT_DEF, MON_DATA_DEF)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5798,6 +5798,10 @@ void PokemonToBattleMon(struct Pokemon *src, struct BattlePokemon *dst)
     dst->type3 = TYPE_MYSTERY;
     dst->ability = GetAbilityBySpecies(dst->species, dst->abilityNum);
     dst->isShadow = GetMonData(src, MON_DATA_IS_SHADOW, NULL);
+    dst->isXD = GetMonData(src, MON_DATA_IS_XD, NULL);
+    dst->shadowAggro = GetMonData(src, MON_DATA_SHADOW_AGGRO, NULL);
+    dst->shadowID = GetMonData(src, MON_DATA_SHADOW_ID, NULL);
+    dst->boostLevel = GetMonData(src, MON_DATA_BOOST_LEVEL, NULL);
     GetMonData(src, MON_DATA_NICKNAME, nickname);
     StringCopy_Nickname(dst->nickname, nickname);
     GetMonData(src, MON_DATA_OT_NAME, dst->otName);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3422,7 +3422,7 @@ void CreateMon(struct Pokemon *mon, u16 species, u8 level, u8 fixedIV, u8 hasFix
     SetMonData(mon, MON_DATA_LEVEL, &level);
     mail = MAIL_NONE;
     SetMonData(mon, MON_DATA_MAIL, &mail);
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, TRUE);
 }
 
 void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, u8 hasFixedPersonality, u32 fixedPersonality, u8 otIdType, u32 fixedOtId)
@@ -3676,7 +3676,7 @@ void CreateMonWithIVsPersonality(struct Pokemon *mon, u16 species, u8 level, u32
 {
     CreateMon(mon, species, level, 0, TRUE, personality, OT_ID_PLAYER_ID, 0);
     SetMonData(mon, MON_DATA_IVS, &ivs);
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, TRUE);
 }
 
 void CreateMonWithIVsOTID(struct Pokemon *mon, u16 species, u8 level, u8 *ivs, u32 otId)
@@ -3688,7 +3688,7 @@ void CreateMonWithIVsOTID(struct Pokemon *mon, u16 species, u8 level, u8 *ivs, u
     SetMonData(mon, MON_DATA_SPEED_IV, &ivs[STAT_SPEED]);
     SetMonData(mon, MON_DATA_SPATK_IV, &ivs[STAT_SPATK]);
     SetMonData(mon, MON_DATA_SPDEF_IV, &ivs[STAT_SPDEF]);
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, TRUE);
 }
 
 void CreateMonWithEVSpread(struct Pokemon *mon, u16 species, u8 level, u8 fixedIV, u8 evSpread)
@@ -3720,7 +3720,7 @@ void CreateMonWithEVSpread(struct Pokemon *mon, u16 species, u8 level, u8 fixedI
         evsBits <<= 1;
     }
 
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, TRUE);
 }
 
 void CreateBattleTowerMon(struct Pokemon *mon, struct BattleTowerPokemon *src)
@@ -3774,7 +3774,7 @@ void CreateBattleTowerMon(struct Pokemon *mon, struct BattleTowerPokemon *src)
     value = src->spDefenseIV;
     SetMonData(mon, MON_DATA_SPDEF_IV, &value);
     MonRestorePP(mon);
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, TRUE);
 }
 
 void CreateBattleTowerMon_HandleLevel(struct Pokemon *mon, struct BattleTowerPokemon *src, bool8 lvl50)
@@ -3836,7 +3836,7 @@ void CreateBattleTowerMon_HandleLevel(struct Pokemon *mon, struct BattleTowerPok
     value = src->spDefenseIV;
     SetMonData(mon, MON_DATA_SPDEF_IV, &value);
     MonRestorePP(mon);
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, TRUE);
 }
 
 void CreateApprenticeMon(struct Pokemon *mon, const struct Apprentice *src, u8 monId)
@@ -3868,7 +3868,7 @@ void CreateApprenticeMon(struct Pokemon *mon, const struct Apprentice *src, u8 m
     language = src->language;
     SetMonData(mon, MON_DATA_LANGUAGE, &language);
     SetMonData(mon, MON_DATA_OT_NAME, GetApprenticeNameInLanguage(src->id, language));
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, FALSE);
 }
 
 void CreateMonWithEVSpreadNatureOTID(struct Pokemon *mon, u16 species, u8 level, u8 nature, u8 fixedIV, u8 evSpread, u32 otId)
@@ -3902,7 +3902,7 @@ void CreateMonWithEVSpreadNatureOTID(struct Pokemon *mon, u16 species, u8 level,
         evsBits <<= 1;
     }
 
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, TRUE);
 }
 
 void ConvertPokemonToBattleTowerPokemon(struct Pokemon *mon, struct BattleTowerPokemon *dest)
@@ -4096,7 +4096,7 @@ static u16 CalculateBoxMonChecksum(struct BoxPokemon *boxMon)
     SetMonData(mon, field, &n);                                 \
 }
 
-void CalculateMonStats(struct Pokemon *mon, bool8 isBoosted)
+void CalculateMonStats(struct Pokemon *mon, bool8 canBeBoosted)
 {
     s32 oldMaxHP = GetMonData(mon, MON_DATA_MAX_HP, NULL);
     s32 currentHP = GetMonData(mon, MON_DATA_HP, NULL);
@@ -4195,7 +4195,7 @@ void BoxMonToMon(const struct BoxPokemon *src, struct Pokemon *dest)
     SetMonData(dest, MON_DATA_MAX_HP, &value);
     value = MAIL_NONE;
     SetMonData(dest, MON_DATA_MAIL, &value);
-    CalculateMonStats(dest);
+    CalculateMonStats(dest, FALSE);
 }
 
 u8 GetLevelFromMonExp(struct Pokemon *mon)
@@ -5943,7 +5943,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
                 if (dataUnsigned != 0) // Failsafe
                 {
                     SetMonData(mon, MON_DATA_EXP, &dataUnsigned);
-                    CalculateMonStats(mon);
+                    CalculateMonStats(mon, FALSE);
                     retVal = FALSE;
                 }
             }
@@ -6043,7 +6043,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
 
                         // Update EVs and stats
                         SetMonData(mon, sGetMonDataEVConstants[temp1], &dataSigned);
-                        CalculateMonStats(mon);
+                        CalculateMonStats(mon, FALSE);
                         itemEffectParam++;
                         retVal = FALSE;
                         break;
@@ -6223,7 +6223,7 @@ bool8 PokemonUseItemEffects(struct Pokemon *mon, u16 item, u8 partyIndex, u8 mov
 
                         // Update EVs and stats
                         SetMonData(mon, sGetMonDataEVConstants[temp1 + 2], &dataSigned);
-                        CalculateMonStats(mon);
+                        CalculateMonStats(mon, FALSE);
                         retVal = FALSE;
                         itemEffectParam++;
                         break;
@@ -8678,7 +8678,7 @@ bool32 TryFormChange(u32 monId, u32 side, u16 method)
     {
         TryToSetBattleFormChangeMoves(&party[monId], method);
         SetMonData(&party[monId], MON_DATA_SPECIES, &targetSpecies);
-        CalculateMonStats(&party[monId]);
+        CalculateMonStats(&party[monId], (side != B_SIDE_PLAYER));
         return TRUE;
     }
 

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -76,7 +76,7 @@ u8 ScriptGiveMon(u16 species, u8 level, u16 item, u32 unused1, u32 unused2, u8 u
     if (targetSpecies != SPECIES_NONE)
     {
         SetMonData(&mon, MON_DATA_SPECIES, &targetSpecies);
-        CalculateMonStats(&mon);
+        CalculateMonStats(&mon, FALSE);
     }
 
     sentToPc = GiveMonToPlayer(&mon);

--- a/src/trade.c
+++ b/src/trade.c
@@ -4570,7 +4570,7 @@ static void CreateInGameTradePokemonInternal(u8 whichPlayerMon, u8 whichInGameTr
             SetMonData(pokemon, MON_DATA_HELD_ITEM, &inGameTrade->heldItem);
         }
     }
-    CalculateMonStats(&gEnemyParty[0]);
+    CalculateMonStats(&gEnemyParty[0], FALSE);
 }
 
 static void GetInGameTradeMail(struct Mail *mail, const struct InGameTrade *trade)

--- a/src/trainer_hill.c
+++ b/src/trainer_hill.c
@@ -929,7 +929,7 @@ static void SetTrainerHillMonLevel(struct Pokemon *mon, u8 level)
 
     SetMonData(mon, MON_DATA_EXP, &exp);
     SetMonData(mon, MON_DATA_LEVEL, &level);
-    CalculateMonStats(mon);
+    CalculateMonStats(mon, TRUE);
 }
 
 u8 GetNumFloorsInTrainerHillChallenge(void)

--- a/test/test_runner_battle.c
+++ b/test/test_runner_battle.c
@@ -1122,7 +1122,7 @@ void Level_(u32 sourceLine, u32 level)
     INVALID_IF(level == 0 || level > MAX_LEVEL, "Illegal level: %d", level);
     SetMonData(DATA.currentMon, MON_DATA_LEVEL, &level);
     SetMonData(DATA.currentMon, MON_DATA_EXP, &gExperienceTables[gSpeciesInfo[species].growthRate][level]);
-    CalculateMonStats(DATA.currentMon);
+    CalculateMonStats(DATA.currentMon, FALSE);
 }
 
 void MaxHP_(u32 sourceLine, u32 maxHP)


### PR DESCRIPTION
Implementation of the Shadow Boost mechanic as it functioned in Pokemon XD: Gale of Darkness

## Description
The Shadow Boost mechanic in Pokemon XD calculated the stats of opponent Shadow Pokemon as if it were a higher level than displayed. Each opponent Shadow Pokemon has a `boostLevel` of up to 3, individually designated per mon.

I've reworked it from the previous iteration I submitted a pull request for -- this time, it uses the preexisting `CalculateMonStats` function rather than creating a nearly identical copy. In order to make it work on such a situational basis, though, I added a second parameter to the function, a boolean determining whether the Pokemon `canBeBoosted` in the scenario where the function is called. This did require sifting through every instance of the `CalculateMonStats` function in the entire repo to determine which scenarios warranted `TRUE` and which ones warranted `FALSE`, but it is now working cleanly.

As a small side note, this PR also adds more properties to the `ShadowData` struct in preparation for future features of the Shadow Pokemon mechanic.

One minor issue: when you snag a Shadow Pokemon and it gets added to your party before the battle is over, the Pokemon still retains the boosted stats until the battle ends, and only recalculates without the boost afterwards. **However,** if we are implementing XD's mechanics properly, then this will be a non-issue, as Shadow Pokemon in XD could not be added to your team until after the battle is over anyway.